### PR TITLE
Handle the outdir option consistently

### DIFF
--- a/src/asn1_prv_compile.erl
+++ b/src/asn1_prv_compile.erl
@@ -43,9 +43,10 @@ do_compile(State) ->
             AsnDir   = filename:join(AppPath, proplists:get_value(asndir, Opts)),
             AsnFiles = filelib:wildcard(filename:join([AppPath, AsnDir, "*.asn1"])),
             OutDir   = filename:join(AppPath, proplists:get_value(outdir, Opts)),
+            Opts1    = lists:keyreplace(outdir, 1, Opts, {outdir, OutDir}),
 
-            file:make_dir(OutDir),
-            lists:foreach(compile_asn_file(Opts), lists:filter(needs_compile(OutDir), AsnFiles))
+            filelib:ensure_dir(filename:join(OutDir, "dummy")),
+            lists:foreach(compile_asn_file(Opts1), lists:filter(needs_compile(OutDir), AsnFiles))
     end.
 
 compile_asn_file(Opts) ->


### PR DESCRIPTION
The outdir option was being expanded to the full path for the purposes of checking output files, but the relative path was being passed into the asn1 compiler. This created some unexpected results when the plugin was being used to compile a dependency. The output files were being placed in a directory at the top level of the project when they should be in a directory relative to the dependency.

Also, use 'filelib:ensure_dir' to create parent directories, if necessary.
